### PR TITLE
Rename minio-storage to minio only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,6 @@ typings/
 lib/
 
 # Custom
-example/verdaccio-minio-storage
+example/verdaccio-minio
 example/*.log
 example/*.har

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM verdaccio/verdaccio:4.2.2
 USER root
 ENV NODE_ENV=production
 RUN yarn global add verdaccio-minio && \
-  ln -s /usr/local/share/.config/yarn/global/node_modules/verdaccio-minio /verdaccio/plugins/verdaccio-minio-storage  && \
+  ln -s /usr/local/share/.config/yarn/global/node_modules/verdaccio-minio /verdaccio/plugins/verdaccio-minio  && \
   chown -R 10001 /usr/local/share/.config/yarn/global/node_modules/verdaccio-minio && \
   chown -R 10001 /verdaccio/plugins
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ yarn global dir
 /usr/local/share/.config/yarn/global
 
 # Create a symbolic link to your package directory in the verdaccio plugin folder
-$ ln -s /usr/local/share/.config/yarn/global/node_modules/verdaccio-minio /verdaccio/plugins/verdaccio-minio-storage
+$ ln -s /usr/local/share/.config/yarn/global/node_modules/verdaccio-minio /verdaccio/plugins/verdaccio-minio
 ```
 
 Then you'll need to provide a configuration file for the minio storage :
@@ -36,7 +36,7 @@ storage: /verdaccio/storage/data
 
 # Here's the plugin configuration option
 store:
-  minio-storage:
+  minio:
     # The HTTP port of your minio instance
     port: 9000
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -3,11 +3,11 @@ FROM verdaccio/verdaccio:4.2.2
 # Install minio plugin
 USER root
 ENV NODE_ENV=production
-COPY verdaccio-minio-storage /usr/local/lib/node_modules/verdaccio-minio-storage
-RUN cd /usr/local/lib/node_modules/verdaccio-minio-storage && \
+COPY verdaccio-minio /usr/local/lib/node_modules/verdaccio-minio
+RUN cd /usr/local/lib/node_modules/verdaccio-minio && \
   yarn install --production --ignore-scripts && \
-  ln -s /usr/local/lib/node_modules/verdaccio-minio-storage /verdaccio/plugins/verdaccio-minio-storage  && \
-  chown -R 10001 /usr/local/lib/node_modules/verdaccio-minio-storage && \
+  ln -s /usr/local/lib/node_modules/verdaccio-minio /verdaccio/plugins/verdaccio-minio  && \
+  chown -R 10001 /usr/local/lib/node_modules/verdaccio-minio && \
   chown -R 10001 /verdaccio/plugins
 
 # Copy config with minio storage defined

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -13,7 +13,7 @@
 plugins: /verdaccio/plugins
 storage: /verdaccio/storage/data
 store:
-  minio-storage:
+  minio:
     port: 9000
     region: us-east-1
     endPoint: minio

--- a/scripts/util
+++ b/scripts/util
@@ -71,10 +71,10 @@ copy() {
   title "Copying build result to example folder"
   {
     root
-    mkdir -p ./example/verdaccio-minio-storage
-    cp package.json ./example/verdaccio-minio-storage
-    cp yarn.lock ./example/verdaccio-minio-storage
-    cp -R lib ./example/verdaccio-minio-storage
+    mkdir -p ./example/verdaccio-minio
+    cp package.json ./example/verdaccio-minio
+    cp yarn.lock ./example/verdaccio-minio
+    cp -R lib ./example/verdaccio-minio
   } || {
     panic "Failed to copy plugin to example"
   }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@ import { wait } from './async';
 import Storage from './storage';
 import Plugin from './index';
 
-const cfg = { ...pcfg, ...config, store: { 'minio-storage': config } };
+const cfg = { ...pcfg, ...config, store: { minio: config } };
 const options = { config: cfg, logger };
 
 // eslint-disable-next-line

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export default class MinioDatabase implements IPluginStorage<PluginConfig> {
     });
 
     this.logger = options.logger;
-    this.config = { ...config.store['minio-storage'] };
+    this.config = { ...config.store.minio };
     this.client = new Client(this.config, this.logger);
     this.tokens = new Tokens(this.client, this.logger);
     this.db = new Database(this.client, this.logger);


### PR DESCRIPTION
This should fix the issue #2 where the the plugin name does not work for
older version of Verdaccio.

It also cleans the naming of the plugin, module, config entry;
avoiding unecessary complexity.