### PR TITLE
Fix plugin version

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {
   IPluginStorage,
 } from '@verdaccio/types';
 
+import { version } from '../package.json';
 import retry, { RetryFunction } from './async';
 import { PluginConfig } from './config';
 import Database from './db';
@@ -17,7 +18,7 @@ import Tokens from './tokens';
 import Client from './client';
 
 export default class MinioDatabase implements IPluginStorage<PluginConfig> {
-  public version = '0.1.0-alpha';
+  public version = version;
   public logger: Logger;
   public config: PluginConfig;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "strict": true,
     "outDir": "lib",
     "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "esModuleInterop": true,
     "typeRoots": ["./node_modules/@verdaccio/types/lib/verdaccio", "./node_modules/@types"]
   }


### PR DESCRIPTION
Use `package.json` version number for the plugin version. Avoiding version number being out of sync.
Fix #6 