### PR TITLE
Test multiple Verdaccio versions during accept

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,5 @@
-FROM verdaccio/verdaccio:4.3.4
+ARG VERDACCIO_TAG=4.3
+FROM verdaccio/verdaccio:$VERDACCIO_TAG
 
 # Install minio plugin
 USER root

--- a/example/docker-compose-4.0.yaml
+++ b/example/docker-compose-4.0.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  verdaccio:
+    build:
+      context: .
+      args:
+        - VERDACCIO_TAG=4.0
+    ports:
+      - 4873:4873
+    depends_on:
+      - minio
+    environment:
+      VERDACCIO_PROTOCOL: http
+      VERDACCIO_PORT: 4873
+
+  minio:
+    image: minio/minio:RELEASE.2019-08-21T19-40-07Z
+    command: server /data
+    volumes:
+      - minio:/data
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ACCESS_KEY: this-is-not-so-secret
+      MINIO_SECRET_KEY: this-is-not-so-secret
+
+volumes:
+  minio:

--- a/example/docker-compose-4.1.yaml
+++ b/example/docker-compose-4.1.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  verdaccio:
+    build:
+      context: .
+      args:
+        - VERDACCIO_TAG=4.1
+    ports:
+      - 4873:4873
+    depends_on:
+      - minio
+    environment:
+      VERDACCIO_PROTOCOL: http
+      VERDACCIO_PORT: 4873
+
+  minio:
+    image: minio/minio:RELEASE.2019-08-21T19-40-07Z
+    command: server /data
+    volumes:
+      - minio:/data
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ACCESS_KEY: this-is-not-so-secret
+      MINIO_SECRET_KEY: this-is-not-so-secret
+
+volumes:
+  minio:

--- a/example/docker-compose-4.2.yaml
+++ b/example/docker-compose-4.2.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  verdaccio:
+    build:
+      context: .
+      args:
+        - VERDACCIO_TAG=4.2
+    ports:
+      - 4873:4873
+    depends_on:
+      - minio
+    environment:
+      VERDACCIO_PROTOCOL: http
+      VERDACCIO_PORT: 4873
+
+  minio:
+    image: minio/minio:RELEASE.2019-08-21T19-40-07Z
+    command: server /data
+    volumes:
+      - minio:/data
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ACCESS_KEY: this-is-not-so-secret
+      MINIO_SECRET_KEY: this-is-not-so-secret
+
+volumes:
+  minio:

--- a/example/docker-compose-4.3.yaml
+++ b/example/docker-compose-4.3.yaml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+  verdaccio:
+    build:
+      context: .
+      args:
+        - VERDACCIO_TAG=4.3
+    ports:
+      - 4873:4873
+    depends_on:
+      - minio
+    environment:
+      VERDACCIO_PROTOCOL: http
+      VERDACCIO_PORT: 4873
+
+  minio:
+    image: minio/minio:RELEASE.2019-08-21T19-40-07Z
+    command: server /data
+    volumes:
+      - minio:/data
+    ports:
+      - 9000:9000
+    environment:
+      MINIO_ACCESS_KEY: this-is-not-so-secret
+      MINIO_SECRET_KEY: this-is-not-so-secret
+
+volumes:
+  minio:

--- a/scripts/accept
+++ b/scripts/accept
@@ -12,22 +12,31 @@ isMinioValid() {
     [[ "$(mc ls example/verdaccio)" =~ 'db.json' ]] || error "Verdaccio database does not exists, meaning a problem happened during plugin initialization"
 
     if mc ls example/verdaccio | grep -q 'async'; then
-      panic "Verdaccio bucket already contains packages, meaning cleanup didn't happend correctly"
+      panic "Verdaccio bucket already contains packages, meaning cleanup didn't happend correctly for v${VERDACCIO_VERSION}"
     fi
   } || {
-    panic "Failed to validate minio state"
+    panic "Failed to validate minio state for v${VERDACCIO_VERSION}"
   }
 }
 
 isYarnAbleToInstall() {
-  title "Try installing dependencies using verdaccio as a proxy"
+  title "Try installing dependencies using verdaccio v${VERDACCIO_VERSION} as a proxy"
   {
     rm -rf ./node_modules
     yarn cache clean
     yarn install --har --verbose --registry=$VERDACCIO_ENDPOINT >"$DIR/../example/out.yarn.log"
   } || {
-    panic "Failed to install dependencies through verdaccio"
+    panic "Failed to install dependencies through verdaccio v${VERDACCIO_VERSION}"
   }
+}
+
+accept() {
+  setVersion $1
+  title "Running acceptance for v${VERDACCIO_VERSION}"
+  start
+  isMinioValid
+  isYarnAbleToInstall
+  cleanup
 }
 
 # Build plugin
@@ -39,17 +48,16 @@ copy
 # Remove old containers to start from scratch
 prune
 
-# Build & Start the containers
-start
-
-# Check if minio is ok
-isMinioValid
-
-# Check if install through verdaccio is ok
-isYarnAbleToInstall
-
-# Stop all containers & remove volumes, but save logs to ./example
-cleanup
+if [ -z "$1" ]; then
+  # Run acceptance tests for all supported versions of Verdaccio
+  accept "4.3"
+  accept "4.2"
+  accept "4.1"
+  accept "4.0"
+else
+  # Run acceptance tests for the given version
+  accept "$1"
+fi
 
 # Go back to project root directory
 root

--- a/scripts/util
+++ b/scripts/util
@@ -13,7 +13,9 @@ MINIO_ENDPOINT=http://127.0.0.1:9000
 MINIO_ACCESS_KEY=this-is-not-so-secret
 MINIO_SECRET_KEY=this-is-not-so-secret
 VERDACCIO_SERVICE=verdaccio
+VERDACCIO_VERSION=4.3
 VERDACCIO_ENDPOINT=http://127.0.0.1:4873
+COMPOSE_FILE="docker-compose-${VERDACCIO_VERSION}.yaml"
 
 root() {
   cd "$DIR/.."
@@ -40,8 +42,17 @@ panic() {
   exit 1
 }
 
+setVersion() {
+  if [ -z "$1" ]; then
+    panic "Cannot set version to nil"
+  fi
+
+  VERDACCIO_VERSION="$1"
+  COMPOSE_FILE="docker-compose-${VERDACCIO_VERSION}.yaml"
+}
+
 isContainerRunning() {
-  if [ -z $(docker-compose ps -q $1) ] || [ -z $(docker ps -q --no-trunc | grep $(docker-compose ps -q $1)) ]; then
+  if [ -z $(docker-compose -f $COMPOSE_FILE ps -q $1) ] || [ -z $(docker ps -q --no-trunc | grep $(docker-compose -f $COMPOSE_FILE ps -q $1)) ]; then
     panic "$1 is not running."
   else
     success "$1 is running."
@@ -50,8 +61,8 @@ isContainerRunning() {
 
 cleanup() {
   example
-  docker-compose logs $VERDACCIO_SERVICE >"$DIR/../example/out.verdaccio.log"
-  mc ls example/verdaccio >"$DIR/../example/out.minio.log"
+  docker-compose -f $COMPOSE_FILE logs $VERDACCIO_SERVICE >"$DIR/../example/out.verdaccio.${VERDACCIO_VERSION}.log"
+  mc ls example/verdaccio >"$DIR/../example/out.minio.${VERDACCIO_VERSION}.log"
   mc config host rm example
   prune
   root
@@ -81,21 +92,21 @@ copy() {
 }
 
 prune() {
-  title "Pruning docker containers & volumes"
+  title "Pruning docker containers & volumes for v${VERDACCIO_VERSION}"
   example
-  docker-compose rm -v --stop --force >/dev/null 2>&1
+  docker-compose -f $COMPOSE_FILE rm -v --stop --force >/dev/null 2>&1
   docker volume rm example_minio >/dev/null 2>&1
 }
 
 start() {
-  title "Starting containers"
+  title "Starting containers for v${VERDACCIO_VERSION}"
   {
     example
-    docker-compose up -d --build
+    docker-compose -f $COMPOSE_FILE up -d --build
     sleep 1s
     isContainerRunning $MINIO_SERVICE
     isContainerRunning $VERDACCIO_SERVICE
   } || {
-    panic "Failed to start the containers"
+    panic "Failed to start the containers for v${VERDACCIO_VERSION}"
   }
 }


### PR DESCRIPTION
With support for multiple Verdaccio versions in mind, it's obvious that
the acceptance script was not sufficient. It was made to test only the
latest version of Verdaccio. This change provide acceptance checks for
all minor versions of Verdaccio 4.x, allowing a better detection of
regression bugs.